### PR TITLE
fix next instruction language mix for german

### DIFF
--- a/de.json
+++ b/de.json
@@ -950,6 +950,6 @@
   "departure_time_destination_instructions": "You cannot set a departure time on the final destination",
   "charger_information": "Charger information",
   "direction_in_distance": "In {{distance}}",
-  "direction_next_instruction": "then",
+  "direction_next_instruction": "dann",
   "charger_information_and_amenities": "Charger information and amenities nearby"
 }

--- a/de.json
+++ b/de.json
@@ -950,6 +950,6 @@
   "departure_time_destination_instructions": "You cannot set a departure time on the final destination",
   "charger_information": "Charger information",
   "direction_in_distance": "In {{distance}}",
-  "direction_next_instruction": "dann",
+  "direction_next_instruction": "und dann",
   "charger_information_and_amenities": "Charger information and amenities nearby"
 }


### PR DESCRIPTION
Problem: The word to combine main and secondary instruction is not translated. It says "XXX, then YYY", but should be "XXX, dann YYY".